### PR TITLE
Cache filtered emojis to Preferences

### DIFF
--- a/android/src/main/java/com/jeffg/emoji_picker/EmojiPickerPlugin.java
+++ b/android/src/main/java/com/jeffg/emoji_picker/EmojiPickerPlugin.java
@@ -1,7 +1,6 @@
 package com.jeffg.emoji_picker;
 
 import androidx.annotation.NonNull;
-import androidx.core.graphics.PaintCompat;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.MethodCall;
@@ -11,6 +10,7 @@ import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 import android.graphics.Paint;
+import androidx.core.graphics.PaintCompat;
 
 /** EmojiPickerPlugin */
 public class EmojiPickerPlugin implements FlutterPlugin, MethodCallHandler {

--- a/android/src/main/java/com/jeffg/emoji_picker/EmojiPickerPlugin.java
+++ b/android/src/main/java/com/jeffg/emoji_picker/EmojiPickerPlugin.java
@@ -12,6 +12,9 @@ import io.flutter.plugin.common.PluginRegistry.Registrar;
 import android.graphics.Paint;
 import androidx.core.graphics.PaintCompat;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /** EmojiPickerPlugin */
 public class EmojiPickerPlugin implements FlutterPlugin, MethodCallHandler {
   @Override
@@ -45,6 +48,16 @@ public class EmojiPickerPlugin implements FlutterPlugin, MethodCallHandler {
     if (call.method.equals("isAvailable")) {
       Paint paint = new Paint();
       result.success(PaintCompat.hasGlyph(paint, call.argument("emoji").toString()));
+    } else if(call.method.equals("checkAvailability")) {
+      Paint paint = new Paint();
+      HashMap<String, String> map = call.argument("emoji");
+      HashMap<String, String> filtered = new HashMap<>();
+      for (Map.Entry entry: map.entrySet()) {
+        if(PaintCompat.hasGlyph(paint, entry.getValue().toString())){
+          filtered.put(entry.getKey().toString(), entry.getValue().toString());
+        }
+      }
+      result.success(filtered);
     } else {
       result.notImplemented();
     }

--- a/android/src/main/java/com/jeffg/emoji_picker/EmojiPickerPlugin.java
+++ b/android/src/main/java/com/jeffg/emoji_picker/EmojiPickerPlugin.java
@@ -1,6 +1,8 @@
 package com.jeffg.emoji_picker;
 
 import androidx.annotation.NonNull;
+import androidx.core.graphics.PaintCompat;
+
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -42,7 +44,7 @@ public class EmojiPickerPlugin implements FlutterPlugin, MethodCallHandler {
   public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
     if (call.method.equals("isAvailable")) {
       Paint paint = new Paint();
-      result.success(paint.hasGlyph(call.argument("emoji").toString()));
+      result.success(PaintCompat.hasGlyph(paint, call.argument("emoji").toString()));
     } else {
       result.notImplemented();
     }


### PR DESCRIPTION
Previously each emoji is looped and verified with Paint.hasGlyph to filter the supported emojis in android. This was taking too long to show the emoji list. 

Instead this PR contains 2 improvements
1. Instead of passing single emoji to EmojiPickerPlugin, now the map of emojis is directly passed to the Native code through a new platform method 'checkAvailability' this returns the filtered Map to flutter. 

2. The map is then stored in shared preference and loaded for subsequent loads. 

These two has improved the load times greatly. Please review and post your suggestions. 